### PR TITLE
Prevent tests from crashing when manager is invalid

### DIFF
--- a/tests/test.c
+++ b/tests/test.c
@@ -9,6 +9,10 @@ int main(int argc, char** argv) {
         printf("mgr null\n");
         return 1;
     }
+    if (!hyprcursor_manager_valid(mgr)) {
+        printf("mgr is invalid\n");
+        return 1;
+    }
 
     struct hyprcursor_cursor_style_info info = {.size = 48};
     if (!hyprcursor_load_theme_style(mgr, info)) {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -4,8 +4,12 @@
 int main(int argc, char** argv) {
     Hyprcursor::CHyprcursorManager mgr(nullptr);
 
-    Hyprcursor::SCursorStyleInfo   style{.size = 48};
+    if (!mgr.valid()) {
+        std::cout << "mgr is invalid\n";
+        return 1;
+    }
 
+    Hyprcursor::SCursorStyleInfo style{.size = 48};
     // preload size 48 for testing
     if (!mgr.loadThemeStyle(style)) {
         std::cout << "failed loading style\n";


### PR DESCRIPTION
Right now, the tests fail for me (presumably because I don't have `HYPRCURSOR_THEME` set, nor do I have any files that include any hyprcursor theme in them.)

This patch with print the error message instead of segfaulting.

(I think ideally, this repo would contain an example hyprcursor, so the test can be run, and also so we can see how to make a hyprcursor without grokking all the code first)