### PR TITLE
Fix clang build by adjusting passed flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # probably evil. Arch's clang is very outdated tho...
     target_compile_options(hyprcursor PUBLIC
         $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++2b -D__cpp_concepts=202002L>
-        -Wno-macro-redefined)
+        -Wno-builtin-macro-redefined)
 endif()
 
 # hyprcursor-util

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,9 @@ target_link_libraries(hyprcursor PkgConfig::deps)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # for std::expected.
     # probably evil. Arch's clang is very outdated tho...
-    target_compile_options(hyprcursor PUBLIC -std=gnu++2b -D__cpp_concepts=202002L -Wno-macro-redefined)
+    target_compile_options(hyprcursor PUBLIC
+        $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++2b -D__cpp_concepts=202002L>
+        -Wno-macro-redefined)
 endif()
 
 # hyprcursor-util


### PR DESCRIPTION
This PR makes shure that the "-std=gnu++2b" flag will only be passed to clang++ but not to clang as clang will error out when this flag is passed.

This also silences the warning that appears caused by the redefinition of the builtin macro "__cpp_concepts" as i assume this was meant by adding "-Wno-macro-redefined" previously.

Tested with clang-17 and clang-18