### PR TITLE
docs: mention aspect ratio of cursors

### DIFF
--- a/docs/MAKING_THEMES.md
+++ b/docs/MAKING_THEMES.md
@@ -77,4 +77,6 @@ If you are using an svg cursor, the size parameter will be ignored.
 
 Mixing png and svg cursor images in one shape will result in an error.
 
+All cursors are required to have an aspect ratio of 1:1.
+
 Please note animated svgs are not supported, you need to add a separate svg for every frame.


### PR DESCRIPTION
The horizontal hotspot for a Cursor was off and we didn't immediately figure out why.
Turns out the viewport was not square. Cursor was fitted and hotspot_x seemed like it was negative.

Figured I add this to maybe save other theme makers some minutes :)