### PR TITLE
fix missing follow in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
 
     hyprlang = {
       url = "github:hyprwm/hyprlang";
+      inputs.systems.follows = "systems";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
this causes an extra instance of the systems flake, and makes it very difficult to overide in upstream flakes