### PR TITLE
Count cursor-less themes as invalid

### DIFF
--- a/include/hyprcursor/hyprcursor.hpp
+++ b/include/hyprcursor/hyprcursor.hpp
@@ -58,6 +58,8 @@ namespace Hyprcursor {
         If none found, bool valid() will be false.
 
         If loading fails, bool valid() will be false.
+
+        If theme has no valid cursor shapes, bool valid() will be false.
     */
     class CHyprcursorManager {
       public:

--- a/libhyprcursor/hyprcursor.cpp
+++ b/libhyprcursor/hyprcursor.cpp
@@ -248,6 +248,11 @@ void CHyprcursorManager::init(const char* themeName_) {
         return;
     }
 
+    if (impl->theme.shapes.empty()) {
+        Debug::log(HC_LOG_ERR, logFn, "Theme {} has no valid cursor shapes\n", impl->themeName);
+        return;
+    }
+
     finalizedAndValid = true;
 }
 


### PR DESCRIPTION
No need to try rendering a theme if it has no loaded cursors.