### PR TITLE
Properly report error on zip_close

### DIFF
--- a/hyprcursor-util/src/main.cpp
+++ b/hyprcursor-util/src/main.cpp
@@ -203,9 +203,8 @@ static std::optional<std::string> createCursorThemeFromPath(const std::string& p
 
         // close zip and write
         if (zip_close(zip) < 0) {
-            zip_error_t ziperror;
-            zip_error_init_with_code(&ziperror, errp);
-            return "Failed to write " + OUTPUTFILE + ": " + zip_error_strerror(&ziperror);
+            zip_error_t* ziperror = zip_get_error(zip);
+            return "Failed to write " + OUTPUTFILE + ": " + zip_error_strerror(ziperror);
         }
 
         std::cout << "Written " << OUTPUTFILE << "\n";


### PR DESCRIPTION
`errp` is only used upon zip creation, after that the errors are stored inside zip

Fixes confusing `Failed to write /…/cursor.hlc: No error` output to actually show the error