### PR TITLE
zip: fix build for some distros (#37)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ configure_file(hyprcursor.pc.in hyprcursor.pc @ONLY)
 set(CMAKE_CXX_STANDARD 23)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(deps REQUIRED IMPORTED_TARGET hyprlang>=0.4.2 libzip>=1.10.1 cairo librsvg-2.0 tomlplusplus)
+pkg_check_modules(deps REQUIRED IMPORTED_TARGET hyprlang>=0.4.2 libzip cairo librsvg-2.0 tomlplusplus)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
     message(STATUS "Configuring hyprcursor in Debug")

--- a/hyprcursor-util/src/main.cpp
+++ b/hyprcursor-util/src/main.cpp
@@ -11,6 +11,10 @@
 #include "manifest.hpp"
 #include "meta.hpp"
 
+#ifndef ZIP_LENGTH_TO_END
+#define ZIP_LENGTH_TO_END -1
+#endif
+
 enum eOperation {
     OPERATION_CREATE  = 0,
     OPERATION_EXTRACT = 1,


### PR DESCRIPTION
libzip 1.10.1 is not available on some distributions. This patch introduces a workaround to fix the build instead of jumping to 1.10.1 release.