### PR TITLE
Correction in hotspot coordinates documentation

### DIFF
--- a/docs/MAKING_THEMES.md
+++ b/docs/MAKING_THEMES.md
@@ -49,7 +49,7 @@ Each cursor image is a separate directory. In it, multiple size variations can b
 resize_algorithm = bilinear
 
 # "hotspot" is where in your cursor the actual "click point" should be.
-# this is in absolute coordinates. x+ is east, y+ is north.
+# this is in absolute coordinates. x+ is east, y+ is south.
 # the pixel coordinates of the hotspot at size are rounded to the nearest:
 # (round(size * hotspot_x), round(size * hotspot_y))
 hotspot_x = 0.0 # this goes 0 - 1


### PR DESCRIPTION
Hotspot coordinates use typical image coordinates originating from top-left (north-west) corner. This is fine, but the accompanying comments imply that it is in the bottom-left corner, saying "x+ is east, y+ is north".

Corrected to say "y+ is south".