### PR TITLE
Unbreak build with libc++

### DIFF
--- a/libhyprcursor/hyprcursor.cpp
+++ b/libhyprcursor/hyprcursor.cpp
@@ -2,6 +2,7 @@
 #include "internalSharedTypes.hpp"
 #include "internalDefines.hpp"
 #include <array>
+#include <sstream>
 #include <cstdio>
 #include <filesystem>
 #include <zip.h>


### PR DESCRIPTION
Regressed by #58

```c++
$ export CC=clang CXX=clang++ CXXFLAGS=-stdlib=libc++
$ cmake -G Ninja -B _build
$ cmake --build _build
[...]
libhyprcursor/hyprcursor.cpp:23:27: error: implicit instantiation of undefined template 'std::basic_stringstream<char>'
   23 |         std::stringstream envXdgStream(envXdgData);
      |                           ^
/usr/include/c++/v1/__fwd/sstream.h:29:28: note: template is declared here
   29 | class _LIBCPP_TEMPLATE_VIS basic_stringstream;
      |                            ^
```
