### PR TITLE
Unbreak hyprcursor-util with libc++

### DIFF
--- a/hyprcursor-util/src/main.cpp
+++ b/hyprcursor-util/src/main.cpp
@@ -2,6 +2,7 @@
 #include <zip.h>
 #include <optional>
 #include <filesystem>
+#include <fstream>
 #include <array>
 #include <format>
 #include <algorithm>


### PR DESCRIPTION
Regressed by hyprlang 0.6.0. See [error log](https://pkg-status.freebsd.org/beefy21/data/141i386-default/2c82e20330b9/logs/errors/hyprcursor-0.1.10.log).