### PR TITLE
core: fix memory leak by freeing rsvg handle

### DIFF
--- a/libhyprcursor/hyprcursor.cpp
+++ b/libhyprcursor/hyprcursor.cpp
@@ -572,12 +572,14 @@ bool CHyprcursorManager::loadThemeStyle(const SCursorStyleInfo& info) {
 
                 if (!rsvg_handle_render_document(handle, PCAIRO, &rect, &error)) {
                     Debug::log(HC_LOG_ERR, logFn, "Failed rendering svg: {}", error->message);
+                    g_object_unref(handle);
                     return false;
                 }
 
                 // done
                 cairo_surface_flush(newImage->cairoSurface);
                 cairo_destroy(PCAIRO);
+                g_object_unref(handle);
             }
         } else {
             Debug::log(HC_LOG_ERR, logFn, "Invalid shapetype in loadThemeStyle");


### PR DESCRIPTION
While I'm testing hyprcursor in my own compositor, I saw increasing memory usage when it load a new size. I can reproduce this in hyprland by repeteadly changing output scale to make hyprland loading a new size. With hyprcursor disabled in hyprland the memory is not increasing. According to [rsvg docs](https://gnome.pages.gitlab.gnome.org/librsvg/Rsvg-2.0/ctor.Handle.new.html#description) the rsvg handle must be freed by using `g_object_unref`.