### PR TITLE
docs: updated MAKING_THEMS.md

### DIFF
--- a/docs/MAKING_THEMES.md
+++ b/docs/MAKING_THEMES.md
@@ -58,6 +58,7 @@ hotspot_y = 0.0 # this goes 0 - 1
 # Define what cursor images this one should override.
 # What this means is that a request for a cursor name e.g. "arrow"
 # will instead use this one, even if this one is named something else.
+# You can see all the available cursor names at https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/cursor-shape/cursor-shape-v1.xml#L71.
 define_override = arrow
 define_override = default
 

--- a/docs/MAKING_THEMES.md
+++ b/docs/MAKING_THEMES.md
@@ -58,7 +58,7 @@ hotspot_y = 0.0 # this goes 0 - 1
 # Define what cursor images this one should override.
 # What this means is that a request for a cursor name e.g. "arrow"
 # will instead use this one, even if this one is named something else.
-# You can see all the available cursor names at https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/cursor-shape/cursor-shape-v1.xml#L71.
+# There is no unified list for all the available cursor names but this wayland list could be used as a reference https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/cursor-shape/cursor-shape-v1.xml#L71 for wayland specific cursors.
 define_override = arrow
 define_override = default
 


### PR DESCRIPTION
While porting a cursor theme made officially for windows. I found it difficult to find out what are the names that the server, compositor may request for me to correctly override them.

At last it was documented well in [wayland protocols](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/cursor-shape/cursor-shape-v1.xml#L71).

> I know hyprland is not for beginners, and have read that warning in the wiki.
> But i strongly think this addition will help some people like me and save some time.

So, I added a link to the docs in the MAKING_THEMES file.
what are your opinions on this @vaxerski 