### PR TITLE
nix: use gcc15

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737469691,
-        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -15,7 +15,7 @@ in {
     inputs.hyprlang.overlays.default
     (final: prev: {
       hyprcursor = prev.callPackage ./default.nix {
-        stdenv = prev.gcc14Stdenv;
+        stdenv = prev.gcc15Stdenv;
         version = version + "+date=" + (mkDate (inputs.self.lastModifiedDate or "19700101")) + "_" + (inputs.self.shortRev or "dirty");
         inherit (final) hyprlang;
       };


### PR DESCRIPTION
changed `gcc14Stdenv` to `gcc15Stdenv` for nix, to match hyprland

updated nixpkgs in flake.lock for gcc15 to be available